### PR TITLE
cmake,test: refac cmake test addition loop in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ file( GLOB_RECURSE WEAVE_SOURCE_FILES ${PROJECT_SOURCE_DIR}/src/*/*.cc ${PROJECT
 add_library(${PROJECT_NAME} STATIC ${WEAVE_SOURCE_FILES})
 LinkAndIncludeLibCurlToExecutable(weave)
 LinkAndIncludeHiredisToExecutable(weave)
+LinkAndIncludespdlogToExecutable(weave)
+LinkAndIncludeOpenCVToExecutable(weave)
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 # cmake_print_variables(UNIT_TESTS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,56 +3,16 @@ include(Libcurl)
 include(LibOpenSSL)
 include(LibOpenCV)
 enable_testing()
-# Test for presence of catch2 compilability
-CompileTestFile(001-catch2_dep_test ${CMAKE_SOURCE_DIR}/tests/001-catch2_dep_test.cc)
 
-CompileTestFile(002-openssl_dep_test ${CMAKE_SOURCE_DIR}/tests/002-openssl_dep_test.cc)
-LinkAndIncludeOpenSSLToExecutable(002-openssl_dep_test)
+file(GLOB TEST_SOURCES ${PROJECT_SOURCE_DIR}/tests/*.cc 
+    ${PROJECT_SOURCE_DIR}/tests/*.cc)
 
-CompileTestFile(003-libcurl_dep_test ${CMAKE_SOURCE_DIR}/tests/003-libcurl_dep_test.cc)
-LinkAndIncludeLibCurlToExecutable(003-libcurl_dep_test)
-
-CompileTestFile(004-hiredis_dep_test ${CMAKE_SOURCE_DIR}/tests/004-hiredis_dep_test.cc)
-LinkAndIncludeHiredisToExecutable(004-hiredis_dep_test)
-
-CompileTestFile(005-spdlog_dep_test ${CMAKE_SOURCE_DIR}/tests/005-spdlog_dep_test.cc)
-LinkAndIncludespdlogToExecutable(005-spdlog_dep_test)
-
-# TODO restructure this
-CompileTestFile(006-http_uri_tests ${CMAKE_SOURCE_DIR}/tests/006-http_uri_tests.cc)
-target_link_libraries(006-http_uri_tests PRIVATE ${PROJECT_NAME})
-
-CompileTestFile(007-opencv_dep_test ${CMAKE_SOURCE_DIR}/tests/007-opencv_dep_test.cc)
-LinkAndIncludeOpenCVToExecutable(007-opencv_dep_test)
-
-CompileTestFile(008-http_protocol_entity_tests
-${CMAKE_SOURCE_DIR}/tests/008-http_protocol_entity_tests.cc)
-target_link_libraries(008-http_protocol_entity_tests PRIVATE ${PROJECT_NAME})
-
-CompileTestFile(009-singleton-contexts
-	${CMAKE_SOURCE_DIR}/tests/009-singleton-contexts.cc)
-target_link_libraries(009-singleton-contexts PRIVATE ${PROJECT_NAME})
-
-CompileTestFile(010-curlhandler-request-tests
-	${CMAKE_SOURCE_DIR}/tests/010-curlhandler-request-tests.cc)
-target_link_libraries(010-curlhandler-request-tests PRIVATE ${PROJECT_NAME})
-
-CompileTestFile(011-curl-set-headers
-	${CMAKE_SOURCE_DIR}/tests/011-curl-set-headers.cc)
-target_link_libraries(011-curl-set-headers PRIVATE ${PROJECT_NAME})
-
-# Dependancy Tests
-add_test(NAME 001-catch2_dep_test
-         COMMAND 001-catch2_dep_test)
-add_test(NAME 002-openssl_dep_test
-         COMMAND 002-openssl_dep_test)
-add_test(NAME 003-libcurl_dep_test
-         COMMAND 003-libcurl_dep_test)
-add_test(NAME 004-hiredis_dep_test
-         COMMAND 004-hiredis_dep_test)
-add_test(NAME 005-spdlog_dep_test
-         COMMAND 005-spdlog_dep_test)
-add_test(NAME 006-http_uri_tests
-         COMMAND 006-http_uri_tests)
-# add_test(NAME 007-opencv_dep_test
-#          COMMAND 007-opencv_dep_test)
+foreach(TEST_FILE_PATH ${TEST_SOURCES})
+        cmake_path(GET TEST_FILE_PATH FILENAME TESTNAME_WITHEXT)
+        cmake_path(GET TESTNAME_WITHEXT STEM TEST_NAME  )
+        message("Test Name : ${TEST_NAME}")
+        CompileTestFile(${TEST_NAME} ${TEST_FILE_PATH})
+        target_link_libraries(${TEST_NAME} PRIVATE ${PROJECT_NAME})
+        add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+endforeach()
+    


### PR DESCRIPTION
- Added mechanism to build all tests placed in `tests/` automatically without too much manual addition of tests in to the `tests/CMakeLists.txt` , scability improved with fewer chance of errors