### PR TITLE
openssl-fix,refac: libdir defect fixed for multilib issue

### DIFF
--- a/cmake/LibOpenSSL.cmake
+++ b/cmake/LibOpenSSL.cmake
@@ -28,7 +28,7 @@ macro(LibOpenSSL OPENSSL_VERSION)
 endmacro(LibOpenSSL)
 
 macro(LinkAndIncludeOpenSSLToExecutable NAME_EXE)
-  target_link_libraries(${NAME_EXE} PRIVATE ${OPENSSL_INSTALL_DIR}/lib64/libssl.a ${OPENSSL_INSTALL_DIR}/lib64/libcrypto.a)
+  target_link_libraries(${NAME_EXE} PRIVATE ${CMAKE_BINARY_DIR}/openssl/lib/libssl.a ${CMAKE_BINARY_DIR}/openssl/lib/libcrypto.a)
   target_include_directories(${NAME_EXE} PRIVATE ${CMAKE_BINARY_DIR}/openssl/include)
 endmacro(LinkAndIncludeOpenSSLToExecutable)
 

--- a/cmake/LibOpenSSL.cmake
+++ b/cmake/LibOpenSSL.cmake
@@ -2,7 +2,7 @@ macro(LibOpenSSL OPENSSL_VERSION)
     set(OPENSSL_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/openssl-src) # default path by CMake
     set(OPENSSL_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/openssl)
     set(OPENSSL_INCLUDE_DIR ${OPENSSL_INSTAL_DIR}/include)
-    set(OPENSSL_CONFIGURE_COMMAND ${OPENSSL_SOURCE_DIR}/config)
+    set(OPENSSL_CONFIGURE_COMMAND ${OPENSSL_SOURCE_DIR}/Configure linux-x86_64)
     include(ExternalProject)
     ExternalProject_Add(
         OpenSSL
@@ -10,7 +10,12 @@ macro(LibOpenSSL OPENSSL_VERSION)
         URL https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz
         USES_TERMINAL_DOWNLOAD TRUE
         CONFIGURE_COMMAND
-            ${OPENSSL_CONFIGURE_COMMAND}
+            ${OPENSSL_CONFIGURE_COMMAND} 
+            # Discussion here //some systems might build in lib64
+            # https://github.com/openssl/openssl/issues/16244
+            # https://github.com/curl/curl/pull/8536
+            no-tests 
+            --libdir=lib
             --prefix=${OPENSSL_INSTALL_DIR}
             --openssldir=${OPENSSL_INSTALL_DIR}
         BUILD_COMMAND make

--- a/cmake/Libcurl.cmake
+++ b/cmake/Libcurl.cmake
@@ -23,6 +23,8 @@ macro(LibCurlFetchInstall LIBCURL_VERSION)
 endmacro(LibCurlFetchInstall)
 
 function(LinkAndIncludeLibCurlToExecutable NAME_EXE)
-  target_link_libraries(${NAME_EXE} PRIVATE ${LIBCURL_INSTALL_DIR}/lib/libcurl.a ${OPENSSL_INSTALL_DIR}/lib64/libssl.a ${OPENSSL_INSTALL_DIR}/lib64/libcrypto.a )
+  target_link_libraries(${NAME_EXE} PRIVATE ${LIBCURL_INSTALL_DIR}/lib/libcurl.a 
+    ${OPENSSL_INSTALL_DIR}/lib/libssl.a 
+    ${OPENSSL_INSTALL_DIR}/lib/libcrypto.a )
   target_include_directories(${NAME_EXE} PRIVATE ${LIBCURL_INSTALL_DIR}/include)
 endfunction(LinkAndIncludeLibCurlToExecutable)

--- a/cmake/Libcurl.cmake
+++ b/cmake/Libcurl.cmake
@@ -9,9 +9,9 @@ macro(LibCurlFetchInstall LIBCURL_VERSION)
     SOURCE_DIR ${LIBCURL_SOURCE_DIR}
     URL https://github.com/curl/curl/releases/download/curl-${LIBCURL_VERSION}/curl-8.8.0.tar.gz
     USES_TERMINAL_DOWNLOAD TRUE
-    CONFIGURE_COMMAND ${LIBCURL_SOURCE_DIR}/configure  # Separate command for configure
+    CONFIGURE_COMMAND ${LIBCURL_SOURCE_DIR}/configure
       --prefix=${LIBCURL_INSTALL_DIR}
-      --with-openssl=${CMAKE_BINARY_DIR}/openssl
+      --with-openssl=${OPENSSL_INSTALL_DIR}
     BUILD_COMMAND make
     TEST_COMMAND ""
     INSTALL_COMMAND make install


### PR DESCRIPTION
- OpenSSL will create lib32/lib64/lib folders accross different enviroment
- This change pins the OpenSSL to use lib folder
- Some refactoring is also done here for variables